### PR TITLE
Ensure dropdown width matches

### DIFF
--- a/ui.dropdownchecklist.js
+++ b/ui.dropdownchecklist.js
@@ -330,6 +330,7 @@
                 }
                 
                 instance.controlWrapper.find(".ui-dropdownchecklist").toggleClass("ui-dropdownchecklist-active");
+		instance.dropWrapper.css('width', instance.controlWrapper.outerWidth() + 'px');
                 instance.dropWrapper.drop = true;
                 $.ui.dropdownchecklist.drop = instance;
                 $(document).bind("click", hide);


### PR DESCRIPTION
Added a line in the show method to resize the the dropdown to the size on the control wrapper. This ensures that the drop down is the appropriate size every time it opens.